### PR TITLE
Use uuid.v4 instead of v1

### DIFF
--- a/src/RealTimeAPI.ts
+++ b/src/RealTimeAPI.ts
@@ -4,7 +4,7 @@
 
 import { Observable } from "rxjs";
 import { WebSocketSubject } from 'rxjs/observable/dom/WebSocketSubject';
-import { v1 as uuid } from "uuid";
+import { v4 as uuid } from "uuid";
 import { SHA256 } from "crypto-js";
 
 export class RealTimeAPI {


### PR DESCRIPTION
v1 is based on timestamp, and gives same uuid when methods/subscriptions are called at the same time.