### PR TITLE
fix: Extended typings for "callMethod"

### DIFF
--- a/src/RealTimeAPI.ts
+++ b/src/RealTimeAPI.ts
@@ -198,7 +198,7 @@ export class RealTimeAPI {
   /**
    * Get Observalble to the Result of Method Call from Rocket.Chat Realtime API
    */
-  public callMethod(method: string, ...params: Array<{}>) {
+  public callMethod(method: string, ...params: Array<{} | null>) {
     let id = uuid();
     this.sendMessage({
       msg: "method",


### PR DESCRIPTION
Based on Realtime API docs, method call should support `null` for dates
https://docs.rocket.chat/api/realtime-api/method-calls/load-history